### PR TITLE
UP CLI commands

### DIFF
--- a/upcli/up/main.py
+++ b/upcli/up/main.py
@@ -1,6 +1,7 @@
 import sys
 from datetime import datetime
 import shlex
+import pkgutil
 
 import uplib
 
@@ -9,19 +10,26 @@ log = uplib.log
 def print_help():
     log.debug("up [prompt]")
 
+def get_modules():
+    up_plugins = []
+    for pkg in pkgutil.iter_modules():
+        if pkg.name.startswith("up_"):
+            up_plugins.append(pkg.name)
+    return up_plugins
 
 def exit_cli(code=-1):
     if code:
         log.error("Exiting up cli with code %s", code)
+        if code == "NO_COMMAND_SPECIFIED":
+            log.error(f"installed plugins:\n{'\n'.join(get_modules())}")
     sys.exit(code)
-
 
 def cli_main():
     now = datetime.now()
     log.info(f"Starting UP cli at {now.isoformat()}")
     args = sys.argv
     len_args = len(args)
-    if len_args < 1:
+    if len_args <= 1:
         print_help()
         exit_cli("NO_COMMAND_SPECIFIED")
     executable = args[0]


### PR DESCRIPTION
Initial idea of create commands to up. Currently, if no command specified, will print installed plugins.
Proper idea:
pass commands like:
```bash
$ up list
Installed plugins:
...
```
some way of know prompts from plugins
```bash
$ up list-prompts splat
splat prompts:
1 - splat create cluster oci-standard
...
```
maybe show more details for each prompt
```bash
$ up prompt=1 splat
prompt: "splat create cluster oci-standard"
  env:
    - AI_OFFLINETOKEN
    - PULL_SECRET
default_volumes: true
default_ports: true
...
```